### PR TITLE
update our wrapped pycontainer.swg to use the version from swig 3.0.11

### DIFF
--- a/swig/python/pycontainer.swg
+++ b/swig/python/pycontainer.swg
@@ -10,10 +10,10 @@
  * since we will use this wrapper with the STL containers, that should
  * be the case.
  * ----------------------------------------------------------------------------- */
- 
+
  /*
   * Twan Koolen, Jan 29 2016:
-  * modified from the swig 3.0.5 version of pycontainer.swg to explicitly 
+  * modified from the swig 3.0.5 version of pycontainer.swg to explicitly
   * call the cast operator on the SwigPySequence_Ref type when assigning a std::vector,
   * i.e. in
   *   template <class SwigPySeq, class Seq>
@@ -24,6 +24,12 @@
   * to
   *   seq->insert(seq->end(), (*it).operator value_type());
   */
+
+ /*
+  * Robin Deits, Jan 24 2017:
+  * Updated from swig 3.0.5 to 3.0.11, maintaining Twan's patch.
+  */
+
 
 %{
 #include <iostream>
@@ -205,7 +211,7 @@ namespace swig {
   check_index(Difference i, size_t size, bool insert = false) {
     if ( i < 0 ) {
       if ((size_t) (-i) <= size)
-	return (size_t) (i + size);
+  return (size_t) (i + size);
     } else if ( (size_t) i < size ) {
       return (size_t) i;
     } else if (insert && ((size_t) i == size)) {
@@ -220,7 +226,7 @@ namespace swig {
     if (step == 0) {
       throw std::invalid_argument("slice step cannot be zero");
     } else if (step > 0) {
-      // Required range: 0 <= i < size, 0 <= j < size
+      // Required range: 0 <= i < size, 0 <= j < size, i <= j
       if (i < 0) {
         ii = 0;
       } else if (i < (Difference)size) {
@@ -228,13 +234,15 @@ namespace swig {
       } else if (insert && (i >= (Difference)size)) {
         ii = (Difference)size;
       }
-      if ( j < 0 ) {
+      if (j < 0) {
         jj = 0;
       } else {
         jj = (j < (Difference)size) ? j : (Difference)size;
       }
+      if (jj < ii)
+        jj = ii;
     } else {
-      // Required range: -1 <= i < size-1, -1 <= j < size-1
+      // Required range: -1 <= i < size-1, -1 <= j < size-1, i >= j
       if (i < -1) {
         ii = -1;
       } else if (i < (Difference) size) {
@@ -247,6 +255,8 @@ namespace swig {
       } else {
         jj = (j < (Difference)size ) ? j : (Difference)(size-1);
       }
+      if (ii < jj)
+        ii = jj;
     }
   }
 
@@ -266,6 +276,19 @@ namespace swig {
     return pos;
   }
 
+  template <class Sequence>
+  inline void
+  erase(Sequence* seq, const typename Sequence::iterator& position) {
+    seq->erase(position);
+  }
+
+  template <class Sequence>
+  struct traits_reserve {
+    static void reserve(Sequence & /*seq*/, typename Sequence::size_type /*n*/) {
+      // This should be specialized for types that support reserve
+    }
+  };
+
   template <class Sequence, class Difference>
   inline Sequence*
   getslice(const Sequence* self, Difference i, Difference j, Py_ssize_t step) {
@@ -283,6 +306,7 @@ namespace swig {
         return new Sequence(sb, se);
       } else {
         Sequence *sequence = new Sequence();
+        swig::traits_reserve<Sequence>::reserve(*sequence, (jj - ii + step - 1) / step);
         typename Sequence::const_iterator it = sb;
         while (it!=se) {
           sequence->push_back(*it);
@@ -293,17 +317,16 @@ namespace swig {
       } 
     } else {
       Sequence *sequence = new Sequence();
-      if (ii > jj) {
-        typename Sequence::const_reverse_iterator sb = self->rbegin();
-        typename Sequence::const_reverse_iterator se = self->rbegin();
-        std::advance(sb,size-ii-1);
-        std::advance(se,size-jj-1);
-        typename Sequence::const_reverse_iterator it = sb;
-        while (it!=se) {
-          sequence->push_back(*it);
-          for (Py_ssize_t c=0; c<-step && it!=se; ++c)
-            it++;
-        }
+      swig::traits_reserve<Sequence>::reserve(*sequence, (ii - jj - step - 1) / -step);
+      typename Sequence::const_reverse_iterator sb = self->rbegin();
+      typename Sequence::const_reverse_iterator se = self->rbegin();
+      std::advance(sb,size-ii-1);
+      std::advance(se,size-jj-1);
+      typename Sequence::const_reverse_iterator it = sb;
+      while (it!=se) {
+        sequence->push_back(*it);
+        for (Py_ssize_t c=0; c<-step && it!=se; ++c)
+          it++;
       }
       return sequence;
     }
@@ -317,12 +340,11 @@ namespace swig {
     Difference jj = 0;
     swig::slice_adjust(i, j, step, size, ii, jj, true);
     if (step > 0) {
-      if (jj < ii)
-        jj = ii;
       if (step == 1) {
         size_t ssize = jj - ii;
         if (ssize <= is.size()) {
           // expanding/staying the same size
+          swig::traits_reserve<Sequence>::reserve(*self, self->size() - ssize + is.size());
           typename Sequence::iterator sb = self->begin();
           typename InputSeq::const_iterator isit = is.begin();
           std::advance(sb,ii);
@@ -356,8 +378,6 @@ namespace swig {
         }
       }
     } else {
-      if (jj > ii)
-        jj = ii;
       size_t replacecount = (ii - jj - step - 1) / -step;
       if (is.size() != replacecount) {
         char msg[1024];
@@ -383,36 +403,32 @@ namespace swig {
     Difference jj = 0;
     swig::slice_adjust(i, j, step, size, ii, jj, true);
     if (step > 0) {
-      if (jj > ii) {
-        typename Sequence::iterator sb = self->begin();
-        std::advance(sb,ii);
-        if (step == 1) {
-          typename Sequence::iterator se = self->begin();
-          std::advance(se,jj);
-          self->erase(sb,se);
-        } else {
-          typename Sequence::iterator it = sb;
-          size_t delcount = (jj - ii + step - 1) / step;
-          while (delcount) {
-            it = self->erase(it);
-            for (Py_ssize_t c=0; c<(step-1) && it != self->end(); ++c)
-              it++;
-            delcount--;
-          }
-        }
-      }
-    } else {
-      if (ii > jj) {
-        typename Sequence::reverse_iterator sb = self->rbegin();
-        std::advance(sb,size-ii-1);
-        typename Sequence::reverse_iterator it = sb;
-        size_t delcount = (ii - jj - step - 1) / -step;
+      typename Sequence::iterator sb = self->begin();
+      std::advance(sb,ii);
+      if (step == 1) {
+        typename Sequence::iterator se = self->begin();
+        std::advance(se,jj);
+        self->erase(sb,se);
+      } else {
+        typename Sequence::iterator it = sb;
+        size_t delcount = (jj - ii + step - 1) / step;
         while (delcount) {
-          it = typename Sequence::reverse_iterator(self->erase((++it).base()));
-          for (Py_ssize_t c=0; c<(-step-1) && it != self->rend(); ++c)
+          it = self->erase(it);
+          for (Py_ssize_t c=0; c<(step-1) && it != self->end(); ++c)
             it++;
           delcount--;
         }
+      }
+    } else {
+      typename Sequence::reverse_iterator sb = self->rbegin();
+      std::advance(sb,size-ii-1);
+      typename Sequence::reverse_iterator it = sb;
+      size_t delcount = (ii - jj - step - 1) / -step;
+      while (delcount) {
+        it = typename Sequence::reverse_iterator(self->erase((++it).base()));
+        for (Py_ssize_t c=0; c<(-step-1) && it != self->rend(); ++c)
+          it++;
+        delcount--;
       }
     }
   }
@@ -420,16 +436,16 @@ namespace swig {
 }
 
 %fragment("SwigPySequence_Cont","header",
-	  fragment="StdTraits",
-	  fragment="SwigPySequence_Base",
-	  fragment="SwigPyIterator_T")
+    fragment="StdTraits",
+    fragment="SwigPySequence_Base",
+    fragment="SwigPyIterator_T")
 {
 namespace swig
 {
   template <class T>
   struct SwigPySequence_Ref
   {
-    SwigPySequence_Ref(PyObject* seq, int index)
+    SwigPySequence_Ref(PyObject* seq, Py_ssize_t index)
       : _seq(seq), _index(index)
     {
     }
@@ -438,16 +454,16 @@ namespace swig
     {
       swig::SwigVar_PyObject item = PySequence_GetItem(_seq, _index);
       try {
-	return swig::as<T>(item, true);
+  return swig::as<T>(item, true);
       } catch (std::exception& e) {
-	char msg[1024];
-	sprintf(msg, "in sequence element %d ", _index);
-	if (!PyErr_Occurred()) {
-	  ::%type_error(swig::type_name<T>());
-	}
-	SWIG_Python_AddErrorMsg(msg);
-	SWIG_Python_AddErrorMsg(e.what());
-	throw;
+  char msg[1024];
+  sprintf(msg, "in sequence element %d ", (int)_index);
+  if (!PyErr_Occurred()) {
+    ::%type_error(swig::type_name<T>());
+  }
+  SWIG_Python_AddErrorMsg(msg);
+  SWIG_Python_AddErrorMsg(e.what());
+  throw;
       }
     }
 
@@ -459,7 +475,7 @@ namespace swig
 
   private:
     PyObject* _seq;
-    int _index;
+    Py_ssize_t _index;
   };
 
   template <class T>
@@ -480,13 +496,13 @@ namespace swig
     typedef Reference reference;
     typedef T value_type;
     typedef T* pointer;
-    typedef int difference_type;
+    typedef Py_ssize_t difference_type;
 
     SwigPySequence_InputIterator()
     {
     }
 
-    SwigPySequence_InputIterator(PyObject* seq, int index)
+    SwigPySequence_InputIterator(PyObject* seq, Py_ssize_t index)
       : _seq(seq), _index(index)
     {
     }
@@ -566,6 +582,7 @@ namespace swig
     difference_type _index;
   };
 
+  // STL container wrapper around a Python sequence
   template <class T>
   struct SwigPySequence_Cont
   {
@@ -573,8 +590,8 @@ namespace swig
     typedef const SwigPySequence_Ref<T> const_reference;
     typedef T value_type;
     typedef T* pointer;
-    typedef int difference_type;
-    typedef int size_type;
+    typedef Py_ssize_t difference_type;
+    typedef size_t size_type;
     typedef const pointer const_pointer;
     typedef SwigPySequence_InputIterator<T, reference> iterator;
     typedef SwigPySequence_InputIterator<T, const_reference> const_iterator;
@@ -582,7 +599,7 @@ namespace swig
     SwigPySequence_Cont(PyObject* seq) : _seq(0)
     {
       if (!PySequence_Check(seq)) {
-	throw std::invalid_argument("a sequence is expected");
+  throw std::invalid_argument("a sequence is expected");
       }
       _seq = seq;
       Py_INCREF(_seq);
@@ -635,17 +652,17 @@ namespace swig
 
     bool check(bool set_err = true) const
     {
-      int s = size();
-      for (int i = 0; i < s; ++i) {
-	swig::SwigVar_PyObject item = PySequence_GetItem(_seq, i);
-	if (!swig::check<value_type>(item)) {
-	  if (set_err) {
-	    char msg[1024];
-	    sprintf(msg, "in sequence element %d", i);
-	    SWIG_Error(SWIG_RuntimeError, msg);
-	  }
-	  return false;
-	}
+      Py_ssize_t s = size();
+      for (Py_ssize_t i = 0; i < s; ++i) {
+  swig::SwigVar_PyObject item = PySequence_GetItem(_seq, i);
+  if (!swig::check<value_type>(item)) {
+    if (set_err) {
+      char msg[1024];
+      sprintf(msg, "in sequence element %d", (int)i);
+      SWIG_Error(SWIG_RuntimeError, msg);
+    }
+    return false;
+  }
       }
       return true;
     }
@@ -667,15 +684,15 @@ namespace swig
   %typemap(out,noblock=1,fragment="SwigPySequence_Cont")
     iterator, reverse_iterator, const_iterator, const_reverse_iterator {
     $result = SWIG_NewPointerObj(swig::make_output_iterator(%static_cast($1,const $type &)),
-				 swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN);
+         swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN);
   }
   %typemap(out,noblock=1,fragment="SwigPySequence_Cont")
     std::pair<iterator, iterator>, std::pair<const_iterator, const_iterator> {
     $result = PyTuple_New(2);
     PyTuple_SetItem($result,0,SWIG_NewPointerObj(swig::make_output_iterator(%static_cast($1,const $type &).first),
-						 swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));
+             swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));
     PyTuple_SetItem($result,1,SWIG_NewPointerObj(swig::make_output_iterator(%static_cast($1,const $type &).second),
-						 swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));    
+             swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));    
   }
 
   %fragment("SwigPyPairBoolOutputIterator","header",fragment=SWIG_From_frag(bool),fragment="SwigPySequence_Cont") {}
@@ -684,7 +701,7 @@ namespace swig
     std::pair<iterator, bool>, std::pair<const_iterator, bool> {
     $result = PyTuple_New(2);
     PyTuple_SetItem($result,0,SWIG_NewPointerObj(swig::make_output_iterator(%static_cast($1,const $type &).first),
-					       swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));    
+                 swig::SwigPyIterator::descriptor(),SWIG_POINTER_OWN));    
     PyTuple_SetItem($result,1,SWIG_From(bool)(%static_cast($1,const $type &).second));
   }
 
@@ -699,9 +716,9 @@ namespace swig
     } else {
       swig::SwigPyIterator_T<$type > *iter_t = dynamic_cast<swig::SwigPyIterator_T<$type > *>(iter);
       if (iter_t) {
-	$1 = iter_t->get_current();
+  $1 = iter_t->get_current();
       } else {
-	%argument_fail(SWIG_TypeError, "$type", $symname, $argnum);
+  %argument_fail(SWIG_TypeError, "$type", $symname, $argnum);
       }
     }
   }
@@ -724,8 +741,8 @@ namespace swig
 #if defined(SWIGPYTHON_BUILTIN)
   %feature("python:slot", "tp_iter", functype="getiterfunc") iterator;
 #else
-  %pythoncode {def __iter__(self):
-    return self.iterator()}
+  %pythoncode %{def __iter__(self):
+    return self.iterator()%}
 #endif
   }
 
@@ -762,7 +779,6 @@ namespace swig
       return self->size();
     }
   }
-
 %enddef
 
 
@@ -770,7 +786,7 @@ namespace swig
 %define %swig_sequence_methods_common(Sequence...)
   %swig_sequence_iterator(%arg(Sequence))
   %swig_container_methods(%arg(Sequence))
-  
+
   %fragment("SwigPySequence_Base");
 
 #if defined(SWIGPYTHON_BUILTIN)
@@ -783,14 +799,6 @@ namespace swig
 #endif // SWIGPYTHON_BUILTIN
 
   %extend {
-    value_type pop() throw (std::out_of_range) {
-      if (self->size() == 0)
-	throw std::out_of_range("pop from empty container");
-      Sequence::value_type x = self->back();
-      self->pop_back();
-      return x;
-    }
-
     /* typemap for slice object support */
     %typemap(in) PySliceObject* {
       if (!PySlice_Check($input)) {
@@ -808,7 +816,11 @@ namespace swig
       return swig::getslice(self, i, j, 1);
     }
 
-    void __setslice__(difference_type i, difference_type j, const Sequence& v = Sequence()) throw (std::out_of_range, std::invalid_argument) {
+    void __setslice__(difference_type i, difference_type j) throw (std::out_of_range, std::invalid_argument) {
+      swig::setslice(self, i, j, 1, Sequence());
+    }
+
+    void __setslice__(difference_type i, difference_type j, const Sequence& v) throw (std::out_of_range, std::invalid_argument) {
       swig::setslice(self, i, j, 1, v);
     }
 
@@ -817,10 +829,9 @@ namespace swig
     }
 #endif
 
-    void __delitem__(difference_type i) throw (std::out_of_range) {
-      self->erase(swig::getpos(self,i));
+    void __delitem__(difference_type i) throw (std::out_of_range, std::invalid_argument) {
+      swig::erase(self, swig::getpos(self, i));
     }
-
 
     /* Overloaded methods for Python 3 compatibility 
      * (Also useful in Python 2.x)
@@ -872,12 +883,11 @@ namespace swig
       Sequence::difference_type jd = j;
       swig::delslice(self, id, jd, step);
     }
-     
-  }
 
+  }
 %enddef
 
-%define %swig_sequence_methods(Sequence...)
+%define %swig_sequence_methods_non_resizable(Sequence...)
   %swig_sequence_methods_common(%arg(Sequence))
   %extend {
     const value_type& __getitem__(difference_type i) const throw (std::out_of_range) {
@@ -890,19 +900,32 @@ namespace swig
 
 #if defined(SWIGPYTHON_BUILTIN)
     // This will be called through the mp_ass_subscript slot to delete an entry.
-    void __setitem__(difference_type i) throw (std::out_of_range) {
-      self->erase(swig::getpos(self,i));
+    void __setitem__(difference_type i) throw (std::out_of_range, std::invalid_argument) {
+      swig::erase(self, swig::getpos(self, i));
     }
 #endif
+
+  }
+%enddef
+
+%define %swig_sequence_methods(Sequence...)
+  %swig_sequence_methods_non_resizable(%arg(Sequence))
+  %extend {
+    value_type pop() throw (std::out_of_range) {
+      if (self->size() == 0)
+  throw std::out_of_range("pop from empty container");
+      Sequence::value_type x = self->back();
+      self->pop_back();
+      return x;
+    }
 
     void append(const value_type& x) {
       self->push_back(x);
     }
- }
-
+  }
 %enddef
 
-%define %swig_sequence_methods_val(Sequence...)
+%define %swig_sequence_methods_non_resizable_val(Sequence...)
   %swig_sequence_methods_common(%arg(Sequence))
   %extend {
     value_type __getitem__(difference_type i) throw (std::out_of_range) {
@@ -915,16 +938,28 @@ namespace swig
 
 #if defined(SWIGPYTHON_BUILTIN)
     // This will be called through the mp_ass_subscript slot to delete an entry.
-    void __setitem__(difference_type i) throw (std::out_of_range) {
-      self->erase(swig::getpos(self,i));
+    void __setitem__(difference_type i) throw (std::out_of_range, std::invalid_argument) {
+      swig::erase(self, swig::getpos(self, i));
     }
 #endif
+  }
+%enddef
+
+%define %swig_sequence_methods_val(Sequence...)
+  %swig_sequence_methods_non_resizable_val(%arg(Sequence))
+  %extend {
+    value_type pop() throw (std::out_of_range) {
+      if (self->size() == 0)
+  throw std::out_of_range("pop from empty container");
+      Sequence::value_type x = self->back();
+      self->pop_back();
+      return x;
+    }
 
     void append(value_type x) {
       self->push_back(x);
     }
- }
-
+  }
 %enddef
 
 
@@ -934,8 +969,8 @@ namespace swig
 //
 
 %fragment("StdSequenceTraits","header",
-	  fragment="StdTraits",
-	  fragment="SwigPySequence_Cont")
+    fragment="StdTraits",
+    fragment="SwigPySequence_Cont")
 {
 namespace swig {
   template <class SwigPySeq, class Seq>
@@ -945,7 +980,7 @@ namespace swig {
     typedef typename SwigPySeq::value_type value_type;
     typename SwigPySeq::const_iterator it = swigpyseq.begin();
     for (;it != swigpyseq.end(); ++it) {
-      seq->insert(seq->end(), (*it).operator value_type());
+      seq->insert(seq->end(),(*it).operator value_type());
     }
   }
 
@@ -956,31 +991,31 @@ namespace swig {
 
     static int asptr(PyObject *obj, sequence **seq) {
       if (obj == Py_None || SWIG_Python_GetSwigThis(obj)) {
-	sequence *p;
-	if (::SWIG_ConvertPtr(obj,(void**)&p,
-			      swig::type_info<sequence>(),0) == SWIG_OK) {
-	  if (seq) *seq = p;
-	  return SWIG_OLDOBJ;
-	}
+  sequence *p;
+  swig_type_info *descriptor = swig::type_info<sequence>();
+  if (descriptor && SWIG_IsOK(::SWIG_ConvertPtr(obj, (void **)&p, descriptor, 0))) {
+    if (seq) *seq = p;
+    return SWIG_OLDOBJ;
+  }
       } else if (PySequence_Check(obj)) {
-	try {
-	  SwigPySequence_Cont<value_type> swigpyseq(obj);
-	  if (seq) {
-	    sequence *pseq = new sequence();
-	    assign(swigpyseq, pseq);
-	    *seq = pseq;
-	    return SWIG_NEWOBJ;
-	  } else {
-	    return swigpyseq.check() ? SWIG_OK : SWIG_ERROR;
-	  }
-	} catch (std::exception& e) {
-	  if (seq) {
-	    if (!PyErr_Occurred()) {
-	      PyErr_SetString(PyExc_TypeError, e.what());
-	    }
-	  }
-	  return SWIG_ERROR;
-	}
+  try {
+    SwigPySequence_Cont<value_type> swigpyseq(obj);
+    if (seq) {
+      sequence *pseq = new sequence();
+      assign(swigpyseq, pseq);
+      *seq = pseq;
+      return SWIG_NEWOBJ;
+    } else {
+      return swigpyseq.check() ? SWIG_OK : SWIG_ERROR;
+    }
+  } catch (std::exception& e) {
+    if (seq) {
+      if (!PyErr_Occurred()) {
+        PyErr_SetString(PyExc_TypeError, e.what());
+      }
+    }
+    return SWIG_ERROR;
+  }
       }
       return SWIG_ERROR;
     }
@@ -997,21 +1032,20 @@ namespace swig {
 %#ifdef SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
       swig_type_info *desc = swig::type_info<sequence>();
       if (desc && desc->clientdata) {
-	return SWIG_NewPointerObj(new sequence(seq), desc, SWIG_POINTER_OWN);
+  return SWIG_InternalNewPointerObj(new sequence(seq), desc, SWIG_POINTER_OWN);
       }
 %#endif
       size_type size = seq.size();
       if (size <= (size_type)INT_MAX) {
-	PyObject *obj = PyTuple_New((int)size);
-	int i = 0;
-	for (const_iterator it = seq.begin();
-	     it != seq.end(); ++it, ++i) {
-	  PyTuple_SetItem(obj,i,swig::from<value_type>(*it));
-	}
-	return obj;
+  PyObject *obj = PyTuple_New((Py_ssize_t)size);
+  Py_ssize_t i = 0;
+  for (const_iterator it = seq.begin(); it != seq.end(); ++it, ++i) {
+    PyTuple_SetItem(obj,i,swig::from<value_type>(*it));
+  }
+  return obj;
       } else {
-	PyErr_SetString(PyExc_OverflowError,"sequence size not valid in python");
-	return NULL;
+  PyErr_SetString(PyExc_OverflowError,"sequence size not valid in python");
+  return NULL;
       }
     }
   };


### PR DESCRIPTION
cc @tkoolen @jamiesnape 

I don't like how brittle this solution is, but I don't see an obvious alternative. 